### PR TITLE
Issue #18: Fix CSS conflict with Bootstrap theme

### DIFF
--- a/css/flickity-carousels.css
+++ b/css/flickity-carousels.css
@@ -13,6 +13,19 @@
   right: -0.5em;
 }
 
+/* Bootstrap themes mangle Flickity styles - override to fix. */
+.flickity-carousel .carousel-item {
+  position: absolute;
+  float: none;
+  display: block;
+  width: auto;
+  box-sizing: content-box;
+  margin: 0;
+}
+.flickity-carousel .carousel-item img {
+  margin: 0;
+}
+
 /* Settings via wrapper item class. */
 .flickity-carousel.cell-full-height .carousel-item {
   min-height: 100%;

--- a/css/flickity-carousels.css
+++ b/css/flickity-carousels.css
@@ -22,7 +22,7 @@
   box-sizing: content-box;
   margin: 0;
 }
-.flickity-carousel .carousel-item img {
+.flickity-carousel .carousel-item img:not([class]) {
   margin: 0;
 }
 


### PR DESCRIPTION
Fixes #18 by resetting styles for "carousel-item" when inside flickity-carousel